### PR TITLE
Feature metrics

### DIFF
--- a/scripts/logstash-ubuntu-install.sh
+++ b/scripts/logstash-ubuntu-install.sh
@@ -278,13 +278,12 @@ EOF_CONF
 
 
     log "[configure_logstash] Generating $LS_CONF_METRICS..."
-    log "[configure_logstash] _metric_from_ tag defined as '${HOSTNAME}'"
 # -----------------------------------------------------------
 cat <<EOF_CONF > $LS_CONF_METRICS
 filter {
   metrics {
-    meter => [ "documents", "_grok_success_syslog", "received_at" ]
-    add_tag => [ "_metrics", "_metric_from_${HOSTNAME}" ]
+    meter => [ "documents" ]
+    add_tag => [ "_metrics" ]
   }
 }
 EOF_CONF

--- a/scripts/logstash-ubuntu-install.sh
+++ b/scripts/logstash-ubuntu-install.sh
@@ -216,21 +216,22 @@ install_additional_plugins()
 
 configure_logstash()
 {
-    local LS_CONF_R=/etc/logstash/conf.d/010-redis-input.conf
-    local LS_CONF_SYSLOG=/etc/logstash/conf.d/020-syslog-filter.conf
-    local LS_CONF_DHCPD=/etc/logstash/conf.d/030-dhcpd-filter.conf    
-    local LS_CONF_ES=/etc/logstash/conf.d/040-elastic-output.conf   
+    local LS_CONF_REDIS=/etc/logstash/conf.d/010-input-redis.conf
+    local LS_CONF_METRICS=/etc/logstash/conf.d/020-filter-metrics.conf
+    local LS_CONF_SYSLOG=/etc/logstash/conf.d/030-filter-syslog.conf
+    local LS_CONF_DHCPD=/etc/logstash/conf.d/040-filter-dhcpd.conf
+    local LS_CONF_ES=/etc/logstash/conf.d/050-output-elastic.conf
     local LS_GROK_DIR=/etc/logstash/patterns.d
 
     log "[configure_logstash] Logstash configuration started..."
 
 
-    log "[configure_logstash] Generating $LS_CONF_R..."
+    log "[configure_logstash] Generating $LS_CONF_REDIS..."
     log "[configure_logstash] Redis defined as '$REDIS_HOST:$REDIS_PORT'"
     log "[configure_logstash] Redis channel defined as '$REDIS_KEY'"
     log "[configure_logstash] _indexed_by_ tag defined as '${HOSTNAME}'"
 # -----------------------------------------------------------
-cat <<EOF_CONF > $LS_CONF_R
+cat <<EOF_CONF > $LS_CONF_REDIS
 input {
   redis {
     host => "localhost"
@@ -252,14 +253,38 @@ EOF_CONF
 
     log "[configure_logstash] Generating $LS_CONF_ES..."
     log "[configure_logstash] Elasticsearch output URI defined as '$ES_URI'"
+    log "[configure_logstash] metrics index defined as 'metrics-${HOSTNAME}-%{+YYYY.MM.dd}'"
 # -----------------------------------------------------------
 cat <<EOF_CONF > $LS_CONF_ES
 output {
-  elasticsearch {
-    hosts => [ "$ES_URI" ]
-    manage_template => false
-    index => "%{[src_id]}-%{[log_type]}-%{+YYYY.MM.dd}"
-    document_type => "%{[log_type]}"
+  if "_metrics" in [tags] {
+    elasticsearch {
+      hosts => [ "$ES_URI" ]
+      manage_template => false
+      index => "metrics-${HOSTNAME}-%{+YYYY.MM.dd}"
+      document_type => "metrics"
+    }
+  } else {
+    elasticsearch {
+      hosts => [ "$ES_URI" ]
+      manage_template => false
+      index => "logs-%{[log_type]}-%{[src_id]}-%{+YYYY.MM.dd}"
+      document_type => "logs-%{[log_type]}"
+    }
+  }
+}
+EOF_CONF
+# -----------------------------------------------------------
+
+
+    log "[configure_logstash] Generating $LS_CONF_METRICS..."
+    log "[configure_logstash] _metric_from_ tag defined as '${HOSTNAME}'"
+# -----------------------------------------------------------
+cat <<EOF_CONF > $LS_CONF_METRICS
+filter {
+  metrics {
+    meter => [ "documents", "_grok_success_syslog", "received_at" ]
+    add_tag => [ "_metrics", "_metric_from_${HOSTNAME}" ]
   }
 }
 EOF_CONF

--- a/scripts/logstash-ubuntu-install.sh
+++ b/scripts/logstash-ubuntu-install.sh
@@ -240,7 +240,7 @@ input {
     key => "$REDIS_KEY"
     data_type => "list"
 
-    threads => 8
+    threads => 2
     codec => "json"
 
     tags => [ "_indexed_by_${HOSTNAME}" ]


### PR DESCRIPTION
Logstash bootstrap now implements throughput metric configuration.

- Drops `/etc/logstash/conf.d/030-filter-syslog.conf` which configures metrics filter to count number of documents per-second rate in a 1- 5- and 15-minute sliding window. Metric records are marked with tag `_metrics`
- Output config is adjusted to route records marked as `_metrics` to the Elasticsearch index `metrics-${HOSTNAME}-%{+YYYY.MM.dd}`